### PR TITLE
Fix count for other types

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -119,7 +119,7 @@ export default class ViewCountPlugin extends Plugin {
 			Logger.debug("Active leaf changed", { viewType });
 			if (viewType === "file-explorer") return;
 
-			if (viewType !== "markdown" && viewType !== "image" && viewType !== "pdf" && viewType !== "dataloom") {
+			if (viewType === "vault-explorer") {
 				Logger.debug("View count not supported for view type", { viewType });
 				this.viewCountStatusBarItem?.setText("");
 				return;

--- a/src/obsidian/view-count-item-view.ts
+++ b/src/obsidian/view-count-item-view.ts
@@ -1,4 +1,4 @@
-import { App, ItemView, MarkdownView, TFile, WorkspaceLeaf } from "obsidian";
+import { App, ItemView, WorkspaceLeaf } from "obsidian";
 import { VIEW_COUNT_ITEM_VIEW } from "src/constants";
 import EventManager from "src/event/event-manager";
 import ViewCountStorage from "src/storage/view-count-storage";
@@ -58,9 +58,9 @@ export default class ViewCountItemView extends ItemView {
 			flairOuterDiv.createDiv({ cls: "tree-item-flair", text: entry.viewCount.toString() });
 
 			itemDiv.addEventListener("click", () => {
-
+				const type = (this.app as any).viewRegistry.getTypeByExtension(file.extension);
 				this.app.workspace.getLeaf(false)?.setViewState({
-					type: file.extension == "canvas" ? "canvas" : "markdown",
+					type,
 					active: true,
 					state: {
 						file: entry.path,


### PR DESCRIPTION
**Fix**
- fix view count not working for canvas, image, and PDF files
- open files as their correct type when clicking on the link displayed in the most viewed pane